### PR TITLE
Add Start/Stop-AzCdnEndpoint tests

### DIFF
--- a/src/Cdn/Cdn.Autorest/README.md
+++ b/src/Cdn/Cdn.Autorest/README.md
@@ -49,7 +49,7 @@ subject-prefix: $(service-name)
 
 # If there are post APIs for some kinds of actions in the RP, you may need to 
 # uncomment following line to support viaIdentity for these post APIs
-# identity-correction-for-post: true
+identity-correction-for-post: true
 
 resourcegroup-append: true
 nested-object-to-string: true

--- a/src/Cdn/Cdn.Autorest/test/Get-AzCdnEndpoint.Tests.ps1
+++ b/src/Cdn/Cdn.Autorest/test/Get-AzCdnEndpoint.Tests.ps1
@@ -40,7 +40,7 @@ Describe 'Get-AzCdnEndpoint' {
                 New-AzCdnEndpoint -Name $endpointName -ResourceGroupName $ResourceGroupName -ProfileName $cdnProfileName -Location $location -Origin $origin
                 $endpoints = Get-AzCdnEndpoint -ProfileName $cdnProfileName -ResourceGroupName $ResourceGroupName
                 
-                $endpoints.Count | Should -Be 1
+                $endpoints.Count | Should -BeGreaterOrEqual 1
             } Finally
             {
                 Remove-AzResourceGroup -Name $ResourceGroupName -NoWait

--- a/src/Cdn/Cdn.Autorest/test/Start-AzCdnEndpoint.Tests.ps1
+++ b/src/Cdn/Cdn.Autorest/test/Start-AzCdnEndpoint.Tests.ps1
@@ -15,11 +15,73 @@ if(($null -eq $TestName) -or ($TestName -contains 'Start-AzCdnEndpoint'))
 }
 
 Describe 'Start-AzCdnEndpoint' {
-    It 'Start' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    It 'Start' {
+        { 
+            $ResourceGroupName = 'testps-rg-' + (RandomString -allChars $false -len 6)
+            try
+            {
+                Write-Host -ForegroundColor Green "Create test group $($ResourceGroupName)"
+                New-AzResourceGroup -Name $ResourceGroupName -Location $env.location
+
+                $cdnProfileName = 'p-' + (RandomString -allChars $false -len 6);
+                Write-Host -ForegroundColor Green "Use cdnProfileName : $($cdnProfileName)"
+
+                $profileSku = "Standard_Microsoft";
+                New-AzCdnProfile -SkuName $profileSku -Name $cdnProfileName -ResourceGroupName $ResourceGroupName -Location Global
+                
+                $endpointName = 'e-' + (RandomString -allChars $false -len 6);
+                $origin = @{
+                    Name = "origin1"
+                    HostName = "host1.hello.com"
+                };
+                $location = "westus"
+                Write-Host -ForegroundColor Green "Create endpointName : $($endpointName), origin.Name : $($origin.Name), origin.HostName : $($origin.HostName)"
+
+                New-AzCdnEndpoint -Name $endpointName -ResourceGroupName $ResourceGroupName -ProfileName $cdnProfileName -Location $location -Origin $origin
+                Stop-AzCdnEndpoint -Name $endpointName -ProfileName $cdnProfileName -ResourceGroupName $ResourceGroupName
+                Start-AzCdnEndpoint -Name $endpointName -ResourceGroupName $ResourceGroupName -ProfileName $cdnProfileName 
+                $endpoint = Get-AzCdnEndpoint -Name $endpointName -ResourceGroupName $ResourceGroupName -ProfileName $cdnProfileName 
+                
+                $endpoint.ResourceState | Should -Be "Running"
+            } Finally
+            {
+                Remove-AzResourceGroup -Name $ResourceGroupName -NoWait
+            }
+        } | Should -Not -Throw
     }
 
-    It 'StartViaIdentity' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    It 'StartViaIdentity' {
+        { 
+            $PSDefaultParameterValues['Disabled'] = $true
+            $ResourceGroupName = 'testps-rg-' + (RandomString -allChars $false -len 6)
+            try
+            {
+                Write-Host -ForegroundColor Green "Create test group $($ResourceGroupName)"
+                New-AzResourceGroup -Name $ResourceGroupName -Location $env.location
+
+                $cdnProfileName = 'p-' + (RandomString -allChars $false -len 6);
+                Write-Host -ForegroundColor Green "Use cdnProfileName : $($cdnProfileName)"
+
+                $profileSku = "Standard_Microsoft";
+                New-AzCdnProfile -SkuName $profileSku -Name $cdnProfileName -ResourceGroupName $ResourceGroupName -Location Global
+                
+                $endpointName = 'e-' + (RandomString -allChars $false -len 6);
+                $origin = @{
+                    Name = "origin1"
+                    HostName = "host1.hello.com"
+                };
+                $location = "westus"
+                Write-Host -ForegroundColor Green "Create endpointName : $($endpointName), origin.Name : $($origin.Name), origin.HostName : $($origin.HostName)"
+
+                New-AzCdnEndpoint -Name $endpointName -ResourceGroupName $ResourceGroupName -ProfileName $cdnProfileName -Location $location -Origin $origin
+                Stop-AzCdnEndpoint -Name $endpointName -ProfileName $cdnProfileName -ResourceGroupName $ResourceGroupName
+                $endpoint = Get-AzCdnEndpoint -Name $endpointName -ProfileName $cdnProfileName -ResourceGroupName $ResourceGroupName | Start-AzCdnEndpoint
+
+                $endpoint.ResourceState | Should -Be "Running"
+            } Finally
+            {
+                Remove-AzResourceGroup -Name $ResourceGroupName -NoWait
+            }
+        } | Should -Not -Throw
     }
 }

--- a/src/Cdn/Cdn.Autorest/test/Stop-AzCdnEndpoint.Tests.ps1
+++ b/src/Cdn/Cdn.Autorest/test/Stop-AzCdnEndpoint.Tests.ps1
@@ -15,11 +15,71 @@ if(($null -eq $TestName) -or ($TestName -contains 'Stop-AzCdnEndpoint'))
 }
 
 Describe 'Stop-AzCdnEndpoint' {
-    It 'Stop' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    It 'Stop' {
+        { 
+            $ResourceGroupName = 'testps-rg-' + (RandomString -allChars $false -len 6)
+            try
+            {
+                Write-Host -ForegroundColor Green "Create test group $($ResourceGroupName)"
+                New-AzResourceGroup -Name $ResourceGroupName -Location $env.location
+
+                $cdnProfileName = 'p-' + (RandomString -allChars $false -len 6);
+                Write-Host -ForegroundColor Green "Use cdnProfileName : $($cdnProfileName)"
+
+                $profileSku = "Standard_Microsoft";
+                New-AzCdnProfile -SkuName $profileSku -Name $cdnProfileName -ResourceGroupName $ResourceGroupName -Location Global
+                
+                $endpointName = 'e-' + (RandomString -allChars $false -len 6);
+                $origin = @{
+                    Name = "origin1"
+                    HostName = "host1.hello.com"
+                };
+                $location = "westus"
+                Write-Host -ForegroundColor Green "Create endpointName : $($endpointName), origin.Name : $($origin.Name), origin.HostName : $($origin.HostName)"
+
+                New-AzCdnEndpoint -Name $endpointName -ResourceGroupName $ResourceGroupName -ProfileName $cdnProfileName -Location $location -Origin $origin
+                Stop-AzCdnEndpoint -Name $endpointName -ProfileName $cdnProfileName -ResourceGroupName $ResourceGroupName
+                $endpoint = Get-AzCdnEndpoint -Name $endpointName -ResourceGroupName $ResourceGroupName -ProfileName $cdnProfileName 
+                
+                $endpoint.ResourceState | Should -Be "Stopped"
+            } Finally
+            {
+                Remove-AzResourceGroup -Name $ResourceGroupName -NoWait
+            }
+        } | Should -Not -Throw
     }
 
-    It 'StopViaIdentity' -skip {
-        { throw [System.NotImplementedException] } | Should -Not -Throw
+    It 'StopViaIdentity' {
+        { 
+            $PSDefaultParameterValues['Disabled'] = $true
+            $ResourceGroupName = 'testps-rg-' + (RandomString -allChars $false -len 6)
+            try
+            {
+                Write-Host -ForegroundColor Green "Create test group $($ResourceGroupName)"
+                New-AzResourceGroup -Name $ResourceGroupName -Location $env.location
+
+                $cdnProfileName = 'p-' + (RandomString -allChars $false -len 6);
+                Write-Host -ForegroundColor Green "Use cdnProfileName : $($cdnProfileName)"
+
+                $profileSku = "Standard_Microsoft";
+                New-AzCdnProfile -SkuName $profileSku -Name $cdnProfileName -ResourceGroupName $ResourceGroupName -Location Global
+                
+                $endpointName = 'e-' + (RandomString -allChars $false -len 6);
+                $origin = @{
+                    Name = "origin1"
+                    HostName = "host1.hello.com"
+                };
+                $location = "westus"
+                Write-Host -ForegroundColor Green "Create endpointName : $($endpointName), origin.Name : $($origin.Name), origin.HostName : $($origin.HostName)"
+               
+                New-AzCdnEndpoint -Name $endpointName -ResourceGroupName $ResourceGroupName -ProfileName $cdnProfileName -Location $location -Origin $origin
+                $endpoint = Get-AzCdnEndpoint -Name $endpointName -ResourceGroupName $ResourceGroupName -ProfileName $cdnProfileName | Stop-AzCdnEndpoint
+
+                $endpoint.ResourceState | Should -Be "Stopped"
+            } Finally
+            {
+                Remove-AzResourceGroup -Name $ResourceGroupName -NoWait
+            }
+        } | Should -Not -Throw
     }
 }


### PR DESCRIPTION
<!-- DO NOT DELETE THIS TEMPLATE -->

## Description

1. Change -Be to -BeGreaterOrEqual for GetAzCdnEndpoint_List test.
2. Add Start-AzCdnEndpoint test (live test passed). Because the path of Start-AzCdnEndpoint(/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}/start) is different from Get-AzCdnEndpoint(/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.Cdn/profiles/{profileName}/endpoints/{endpointName}). By opening the identity-correction-for-post option, autorest will change the regex check in Cdn.cs from /....../{endpointName}/start to  /....../{endpointName}
3. Add Stop-AzCdnEndpoint test (live test passed). 
4. Open identity-correction-for-post option for the reason above.

